### PR TITLE
remove unused build variable

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,3 @@
-{% set build = 0 %}
 {% set version = "3.8.3" %}
 {% set sha256 = '60a10ba01151b904f68b52f6d5da5830acf5f82ad7d9778711e62ffcf82ec2ca' %}
 {% set blas = os.environ.get('BLAS') or 'openblas' %}


### PR DESCRIPTION
bots/rerenders update the build number directly, so don't use a variable