### PR TITLE
remove blas_openblas feature

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,10 +18,7 @@ build:
   # so we find libgcc_ext.10.5
   # I think it's a mistake that petsc looks for this lib
   merge_build_host: true  # [osx]
-  number: 1002
-  # do not remove feature until blas mpkg stops using track_features
-  features:
-    - blas_openblas
+  number: 1003
   run_exports:
     - {{ pin_subpackage('slepc', min_pin='x.x', max_pin='x.x') }}
 


### PR DESCRIPTION
it is being hotfixed out of the blas metapackage
so we don't need it anymore (we never should have added it,
but we couldn't remove it until blas was hotfixed to remove track_features