### PR TITLE
add build for complex numbers

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,12 +8,20 @@ jobs:
     vmImage: ubuntu-16.04
   strategy:
     matrix:
-      linux_64_mpimpich:
-        CONFIG: linux_64_mpimpich
+      linux_64_mpimpichscalarcomplex:
+        CONFIG: linux_64_mpimpichscalarcomplex
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
-      linux_64_mpiopenmpi:
-        CONFIG: linux_64_mpiopenmpi
+      linux_64_mpimpichscalarreal:
+        CONFIG: linux_64_mpimpichscalarreal
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_mpiopenmpiscalarcomplex:
+        CONFIG: linux_64_mpiopenmpiscalarcomplex
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_mpiopenmpiscalarreal:
+        CONFIG: linux_64_mpiopenmpiscalarreal
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,11 +8,17 @@ jobs:
     vmImage: macOS-10.15
   strategy:
     matrix:
-      osx_64_mpimpich:
-        CONFIG: osx_64_mpimpich
+      osx_64_mpimpichscalarcomplex:
+        CONFIG: osx_64_mpimpichscalarcomplex
         UPLOAD_PACKAGES: 'True'
-      osx_64_mpiopenmpi:
-        CONFIG: osx_64_mpiopenmpi
+      osx_64_mpimpichscalarreal:
+        CONFIG: osx_64_mpimpichscalarreal
+        UPLOAD_PACKAGES: 'True'
+      osx_64_mpiopenmpiscalarcomplex:
+        CONFIG: osx_64_mpiopenmpiscalarcomplex
+        UPLOAD_PACKAGES: 'True'
+      osx_64_mpiopenmpiscalarreal:
+        CONFIG: osx_64_mpiopenmpiscalarreal
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 

--- a/.ci_support/linux_64_mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpimpichscalarcomplex.yaml
@@ -1,0 +1,47 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '9'
+libblas:
+- 3.8 *netlib
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
+mpi:
+- mpich
+petsc:
+- '3.14'
+pin_run_as_build:
+  petsc:
+    max_pin: x.x
+  suitesparse:
+    max_pin: x.x
+scalar:
+- complex
+suitesparse:
+- '5'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_mpimpichscalarreal.yaml
+++ b/.ci_support/linux_64_mpimpichscalarreal.yaml
@@ -1,0 +1,47 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '9'
+libblas:
+- 3.8 *netlib
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
+mpi:
+- mpich
+petsc:
+- '3.14'
+pin_run_as_build:
+  petsc:
+    max_pin: x.x
+  suitesparse:
+    max_pin: x.x
+scalar:
+- real
+suitesparse:
+- '5'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpiopenmpiscalarcomplex.yaml
@@ -1,0 +1,47 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '9'
+libblas:
+- 3.8 *netlib
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
+mpi:
+- openmpi
+petsc:
+- '3.14'
+pin_run_as_build:
+  petsc:
+    max_pin: x.x
+  suitesparse:
+    max_pin: x.x
+scalar:
+- complex
+suitesparse:
+- '5'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_64_mpiopenmpiscalarreal.yaml
@@ -1,17 +1,19 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '11'
+- '9'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '11'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -22,8 +24,6 @@ libcblas:
 - 3.8 *netlib
 liblapack:
 - 3.8 *netlib
-macos_machine:
-- x86_64-apple-darwin13.4.0
 mpi:
 - openmpi
 petsc:
@@ -32,12 +32,16 @@ pin_run_as_build:
   petsc:
     max_pin: x.x
   suitesparse:
-    max_pin: x.x.x
+    max_pin: x.x
+scalar:
+- real
 suitesparse:
 - '5'
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_aarch64_mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpimpichscalarcomplex.yaml
@@ -37,6 +37,8 @@ pin_run_as_build:
     max_pin: x.x
   suitesparse:
     max_pin: x.x
+scalar:
+- complex
 suitesparse:
 - '5'
 target_platform:

--- a/.ci_support/linux_aarch64_mpimpichscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpimpichscalarreal.yaml
@@ -1,0 +1,49 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '9'
+libblas:
+- 3.8 *netlib
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
+mpi:
+- mpich
+petsc:
+- '3.14'
+pin_run_as_build:
+  petsc:
+    max_pin: x.x
+  suitesparse:
+    max_pin: x.x
+scalar:
+- real
+suitesparse:
+- '5'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/linux_aarch64_mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpiscalarcomplex.yaml
@@ -1,11 +1,15 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
 - '9'
+cdt_arch:
+- aarch64
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -13,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-aarch64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -33,10 +37,12 @@ pin_run_as_build:
     max_pin: x.x
   suitesparse:
     max_pin: x.x
+scalar:
+- complex
 suitesparse:
 - '5'
 target_platform:
-- linux-ppc64le
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpiscalarreal.yaml
@@ -37,6 +37,8 @@ pin_run_as_build:
     max_pin: x.x
   suitesparse:
     max_pin: x.x
+scalar:
+- real
 suitesparse:
 - '5'
 target_platform:

--- a/.ci_support/linux_ppc64le_mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichscalarcomplex.yaml
@@ -1,17 +1,19 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '11'
+- '9'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '11'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -22,8 +24,6 @@ libcblas:
 - 3.8 *netlib
 liblapack:
 - 3.8 *netlib
-macos_machine:
-- x86_64-apple-darwin13.4.0
 mpi:
 - mpich
 petsc:
@@ -32,11 +32,13 @@ pin_run_as_build:
   petsc:
     max_pin: x.x
   suitesparse:
-    max_pin: x.x.x
+    max_pin: x.x
+scalar:
+- complex
 suitesparse:
 - '5'
 target_platform:
-- osx-64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_mpimpichscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichscalarreal.yaml
@@ -1,0 +1,45 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '9'
+libblas:
+- 3.8 *netlib
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
+mpi:
+- mpich
+petsc:
+- '3.14'
+pin_run_as_build:
+  petsc:
+    max_pin: x.x
+  suitesparse:
+    max_pin: x.x
+scalar:
+- real
+suitesparse:
+- '5'
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/linux_ppc64le_mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpiscalarcomplex.yaml
@@ -1,0 +1,45 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '9'
+libblas:
+- 3.8 *netlib
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
+mpi:
+- openmpi
+petsc:
+- '3.14'
+pin_run_as_build:
+  petsc:
+    max_pin: x.x
+  suitesparse:
+    max_pin: x.x
+scalar:
+- complex
+suitesparse:
+- '5'
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/linux_ppc64le_mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpiscalarreal.yaml
@@ -1,0 +1,45 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '9'
+libblas:
+- 3.8 *netlib
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
+mpi:
+- openmpi
+petsc:
+- '3.14'
+pin_run_as_build:
+  petsc:
+    max_pin: x.x
+  suitesparse:
+    max_pin: x.x
+scalar:
+- real
+suitesparse:
+- '5'
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/osx_64_mpimpichscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichscalarcomplex.yaml
@@ -1,19 +1,17 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '9'
-cdt_name:
-- cos6
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '9'
-docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- '11'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -24,6 +22,8 @@ libcblas:
 - 3.8 *netlib
 liblapack:
 - 3.8 *netlib
+macos_machine:
+- x86_64-apple-darwin13.4.0
 mpi:
 - mpich
 petsc:
@@ -32,14 +32,14 @@ pin_run_as_build:
   petsc:
     max_pin: x.x
   suitesparse:
-    max_pin: x.x
+    max_pin: x.x.x
+scalar:
+- complex
 suitesparse:
 - '5'
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
-- - cdt_name
-  - docker_image

--- a/.ci_support/osx_64_mpimpichscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichscalarreal.yaml
@@ -1,19 +1,17 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '9'
-cdt_name:
-- cos6
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '9'
-docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- '11'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -24,22 +22,24 @@ libcblas:
 - 3.8 *netlib
 liblapack:
 - 3.8 *netlib
+macos_machine:
+- x86_64-apple-darwin13.4.0
 mpi:
-- openmpi
+- mpich
 petsc:
 - '3.14'
 pin_run_as_build:
   petsc:
     max_pin: x.x
   suitesparse:
-    max_pin: x.x
+    max_pin: x.x.x
+scalar:
+- real
 suitesparse:
 - '5'
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
-- - cdt_name
-  - docker_image

--- a/.ci_support/osx_64_mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpiscalarcomplex.yaml
@@ -1,0 +1,45 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '9'
+libblas:
+- 3.8 *netlib
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
+macos_machine:
+- x86_64-apple-darwin13.4.0
+mpi:
+- openmpi
+petsc:
+- '3.14'
+pin_run_as_build:
+  petsc:
+    max_pin: x.x
+  suitesparse:
+    max_pin: x.x.x
+scalar:
+- complex
+suitesparse:
+- '5'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version

--- a/.ci_support/osx_64_mpiopenmpiscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpiscalarreal.yaml
@@ -1,19 +1,17 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '9'
-cdt_name:
-- cos7
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '9'
-docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le
+- '11'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -24,19 +22,23 @@ libcblas:
 - 3.8 *netlib
 liblapack:
 - 3.8 *netlib
+macos_machine:
+- x86_64-apple-darwin13.4.0
 mpi:
-- mpich
+- openmpi
 petsc:
 - '3.14'
 pin_run_as_build:
   petsc:
     max_pin: x.x
   suitesparse:
-    max_pin: x.x
+    max_pin: x.x.x
+scalar:
+- real
 suitesparse:
 - '5'
 target_platform:
-- linux-ppc64le
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 ---
 kind: pipeline
-name: linux_aarch64_mpimpich
+name: linux_aarch64_mpimpichscalarcomplex
 
 platform:
   os: linux
@@ -10,7 +10,7 @@ steps:
 - name: Install and build
   image: quay.io/condaforge/linux-anvil-aarch64
   environment:
-    CONFIG: linux_aarch64_mpimpich
+    CONFIG: linux_aarch64_mpimpichscalarcomplex
     UPLOAD_PACKAGES: True
     PLATFORM: linux-aarch64
     BINSTAR_TOKEN:
@@ -31,7 +31,7 @@ steps:
 
 ---
 kind: pipeline
-name: linux_aarch64_mpiopenmpi
+name: linux_aarch64_mpimpichscalarreal
 
 platform:
   os: linux
@@ -41,7 +41,69 @@ steps:
 - name: Install and build
   image: quay.io/condaforge/linux-anvil-aarch64
   environment:
-    CONFIG: linux_aarch64_mpiopenmpi
+    CONFIG: linux_aarch64_mpimpichscalarreal
+    UPLOAD_PACKAGES: True
+    PLATFORM: linux-aarch64
+    BINSTAR_TOKEN:
+      from_secret: BINSTAR_TOKEN
+    FEEDSTOCK_TOKEN:
+      from_secret: FEEDSTOCK_TOKEN
+    STAGING_BINSTAR_TOKEN:
+      from_secret: STAGING_BINSTAR_TOKEN
+  commands:
+    - export FEEDSTOCK_ROOT="$DRONE_WORKSPACE"
+    - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"
+    - export CI=drone
+    - export GIT_BRANCH="$DRONE_BRANCH"
+    - export FEEDSTOCK_NAME=$(basename ${DRONE_REPO_NAME})
+    - sed -i '$ichown -R conda:conda "$FEEDSTOCK_ROOT"' /opt/docker/bin/entrypoint
+    - /opt/docker/bin/entrypoint $FEEDSTOCK_ROOT/.scripts/build_steps.sh
+    - echo "Done building"
+
+---
+kind: pipeline
+name: linux_aarch64_mpiopenmpiscalarcomplex
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Install and build
+  image: quay.io/condaforge/linux-anvil-aarch64
+  environment:
+    CONFIG: linux_aarch64_mpiopenmpiscalarcomplex
+    UPLOAD_PACKAGES: True
+    PLATFORM: linux-aarch64
+    BINSTAR_TOKEN:
+      from_secret: BINSTAR_TOKEN
+    FEEDSTOCK_TOKEN:
+      from_secret: FEEDSTOCK_TOKEN
+    STAGING_BINSTAR_TOKEN:
+      from_secret: STAGING_BINSTAR_TOKEN
+  commands:
+    - export FEEDSTOCK_ROOT="$DRONE_WORKSPACE"
+    - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"
+    - export CI=drone
+    - export GIT_BRANCH="$DRONE_BRANCH"
+    - export FEEDSTOCK_NAME=$(basename ${DRONE_REPO_NAME})
+    - sed -i '$ichown -R conda:conda "$FEEDSTOCK_ROOT"' /opt/docker/bin/entrypoint
+    - /opt/docker/bin/entrypoint $FEEDSTOCK_ROOT/.scripts/build_steps.sh
+    - echo "Done building"
+
+---
+kind: pipeline
+name: linux_aarch64_mpiopenmpiscalarreal
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Install and build
+  image: quay.io/condaforge/linux-anvil-aarch64
+  environment:
+    CONFIG: linux_aarch64_mpiopenmpiscalarreal
     UPLOAD_PACKAGES: True
     PLATFORM: linux-aarch64
     BINSTAR_TOKEN:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,22 @@ language: generic
 
 matrix:
   include:
-    - env: CONFIG=linux_ppc64le_mpimpich UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_mpimpichscalarcomplex UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
       dist: focal
 
-    - env: CONFIG=linux_ppc64le_mpiopenmpi UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_mpimpichscalarreal UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+      dist: focal
+
+    - env: CONFIG=linux_ppc64le_mpiopenmpiscalarcomplex UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+      dist: focal
+
+    - env: CONFIG=linux_ppc64le_mpiopenmpiscalarreal UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
       dist: focal

--- a/README.md
+++ b/README.md
@@ -41,59 +41,115 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_mpimpich</td>
+              <td>linux_64_mpimpichscalarcomplex</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1925&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc-feedstock?branchName=master&jobName=linux&configuration=linux_64_mpimpich" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc-feedstock?branchName=master&jobName=linux&configuration=linux_64_mpimpichscalarcomplex" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_mpiopenmpi</td>
+              <td>linux_64_mpimpichscalarreal</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1925&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc-feedstock?branchName=master&jobName=linux&configuration=linux_64_mpiopenmpi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc-feedstock?branchName=master&jobName=linux&configuration=linux_64_mpimpichscalarreal" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_mpimpich</td>
+              <td>linux_64_mpiopenmpiscalarcomplex</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1925&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_mpimpich" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc-feedstock?branchName=master&jobName=linux&configuration=linux_64_mpiopenmpiscalarcomplex" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_mpiopenmpi</td>
+              <td>linux_64_mpiopenmpiscalarreal</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1925&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_mpiopenmpi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc-feedstock?branchName=master&jobName=linux&configuration=linux_64_mpiopenmpiscalarreal" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_mpimpich</td>
+              <td>linux_aarch64_mpimpichscalarcomplex</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1925&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_mpimpich" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_mpimpichscalarcomplex" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_mpiopenmpi</td>
+              <td>linux_aarch64_mpimpichscalarreal</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1925&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_mpiopenmpi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_mpimpichscalarreal" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_mpimpich</td>
+              <td>linux_aarch64_mpiopenmpiscalarcomplex</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1925&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc-feedstock?branchName=master&jobName=osx&configuration=osx_64_mpimpich" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_mpiopenmpiscalarcomplex" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_mpiopenmpi</td>
+              <td>linux_aarch64_mpiopenmpiscalarreal</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1925&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc-feedstock?branchName=master&jobName=osx&configuration=osx_64_mpiopenmpi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_mpiopenmpiscalarreal" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_mpimpichscalarcomplex</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1925&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_mpimpichscalarcomplex" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_mpimpichscalarreal</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1925&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_mpimpichscalarreal" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_mpiopenmpiscalarcomplex</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1925&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_mpiopenmpiscalarcomplex" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_mpiopenmpiscalarreal</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1925&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_mpiopenmpiscalarreal" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_mpimpichscalarcomplex</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1925&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc-feedstock?branchName=master&jobName=osx&configuration=osx_64_mpimpichscalarcomplex" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_mpimpichscalarreal</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1925&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc-feedstock?branchName=master&jobName=osx&configuration=osx_64_mpimpichscalarreal" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_mpiopenmpiscalarcomplex</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1925&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc-feedstock?branchName=master&jobName=osx&configuration=osx_64_mpiopenmpiscalarcomplex" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_mpiopenmpiscalarreal</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1925&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/slepc-feedstock?branchName=master&jobName=osx&configuration=osx_64_mpiopenmpiscalarreal" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -17,7 +17,8 @@ ln -s ${BUILD_PREFIX}/bin/make     ${PREFIX}/bin
 ln -s ${BUILD_PREFIX}/bin/dsymutil ${PREFIX}/bin
 
 python ./configure \
-  --prefix=$PREFIX || (cat configure.log && exit 1)
+  --prefix=$PREFIX || (cat configure.log && exit 1) \
+  --with-scalar-type=${scalar}
 
 sedinplace() {
   if [[ $(uname) == Darwin ]]; then

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -17,7 +17,6 @@ ln -s ${BUILD_PREFIX}/bin/make     ${PREFIX}/bin
 ln -s ${BUILD_PREFIX}/bin/dsymutil ${PREFIX}/bin
 
 python ./configure \
-  --with-scalar-type=${scalar} \
   --prefix=$PREFIX || (cat configure.log && exit 1)
 
 sedinplace() {

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -17,8 +17,8 @@ ln -s ${BUILD_PREFIX}/bin/make     ${PREFIX}/bin
 ln -s ${BUILD_PREFIX}/bin/dsymutil ${PREFIX}/bin
 
 python ./configure \
-  --prefix=$PREFIX || (cat configure.log && exit 1) \
-  --with-scalar-type=${scalar}
+  --with-scalar-type=${scalar} \
+  --prefix=$PREFIX || (cat configure.log && exit 1)
 
 sedinplace() {
   if [[ $(uname) == Darwin ]]; then

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,9 @@
 mpi:
   - mpich
   - openmpi
+scalar:
+  - real
+  - complex
 pin_run_as_build:
   mpich:
     min_pin: x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - suitesparse
   run:
     - {{ mpi }}
-    - petsc
+    - petsc * *{{ scalar }}*
     - suitesparse
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,12 @@
 {% set version = "3.15.1" %}
 {% set sha256 = "9c7c3a45f0d9df51decf357abe090ef05114c38a69b7836386a19a96fb203aea" %}
+{% set build = 1 %}
 
 {% set version_xy = version.rsplit(".", 1)[0] %}
 {% set mpi = mpi or 'mpich' %}
+{% if scalar == "real" %}
+{% set build = build + 100 %}
+{% endif %}
 
 package:
   name: slepc
@@ -14,9 +18,12 @@ source:
 
 build:
   skip: true  # [win]
-  number: 0
+  number: {{ build }}
+  string: {{ scalar }}_h{{ PKG_HASH }}_{{ build }}
   run_exports:
     - {{ pin_subpackage('slepc', max_pin='x.x') }}
+  track_features:
+    - slepc_complex  # [scalar == "complex"]
 
 requirements:
   build:
@@ -30,7 +37,7 @@ requirements:
     - libcblas
     - liblapack
     - {{ mpi }}
-    - petsc {{ version_xy }}.*
+    - petsc {{ version_xy }}.* *{{ scalar }}*
     - suitesparse
   run:
     - {{ mpi }}


### PR DESCRIPTION
add variant of build for complex numbers.
this build can be selected via `slepc=*=*complex*`.

the build for real numbers remains the default.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
