### PR TITLE
rely on petsc run_exports for runtime petsc version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "3.17.1" %}
 {% set sha256 = "11386cd3f4c0f9727af3c1c59141cc4bf5f83bdf7c50251de0845e406816f575" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 {% set version_xy = version.rsplit(".", 1)[0] %}
 {% set mpi = mpi or 'mpich' %}
@@ -39,11 +39,11 @@ requirements:
     - libcblas
     - liblapack
     - {{ mpi }}
-    - petsc {{ version_xy }}.* *{{ scalar }}*
+    - petsc {{ version_xy }}.* {{ scalar }}_*
     - suitesparse
   run:
     - {{ mpi }}
-    - petsc * *{{ scalar }}*
+    - petsc
     - suitesparse
 
 test:


### PR DESCRIPTION
avoids mismatched globs (https://github.com/conda-forge/petsc-feedstock/issues/147)

needed for anything built against petsc that had manual runtime dependencies pinning the build string in a way that didn't match petsc's run_exports.