### PR TITLE
Explicit dependency on mumps, rebuild for mumps 5.6.2

### DIFF
--- a/.ci_support/linux_64_mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpimpichscalarcomplex.yaml
@@ -28,6 +28,8 @@ mpi:
 - mpich
 mpich:
 - '4'
+mumps_mpi:
+- 5.6.2
 openmpi:
 - '4'
 petsc:

--- a/.ci_support/linux_64_mpimpichscalarreal.yaml
+++ b/.ci_support/linux_64_mpimpichscalarreal.yaml
@@ -28,6 +28,8 @@ mpi:
 - mpich
 mpich:
 - '4'
+mumps_mpi:
+- 5.6.2
 openmpi:
 - '4'
 petsc:

--- a/.ci_support/linux_64_mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_64_mpiopenmpiscalarcomplex.yaml
@@ -28,6 +28,8 @@ mpi:
 - openmpi
 mpich:
 - '4'
+mumps_mpi:
+- 5.6.2
 openmpi:
 - '4'
 petsc:

--- a/.ci_support/linux_64_mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_64_mpiopenmpiscalarreal.yaml
@@ -28,6 +28,8 @@ mpi:
 - openmpi
 mpich:
 - '4'
+mumps_mpi:
+- 5.6.2
 openmpi:
 - '4'
 petsc:

--- a/.ci_support/linux_aarch64_mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpimpichscalarcomplex.yaml
@@ -32,6 +32,8 @@ mpi:
 - mpich
 mpich:
 - '4'
+mumps_mpi:
+- 5.6.2
 openmpi:
 - '4'
 petsc:

--- a/.ci_support/linux_aarch64_mpimpichscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpimpichscalarreal.yaml
@@ -32,6 +32,8 @@ mpi:
 - mpich
 mpich:
 - '4'
+mumps_mpi:
+- 5.6.2
 openmpi:
 - '4'
 petsc:

--- a/.ci_support/linux_aarch64_mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpiscalarcomplex.yaml
@@ -32,6 +32,8 @@ mpi:
 - openmpi
 mpich:
 - '4'
+mumps_mpi:
+- 5.6.2
 openmpi:
 - '4'
 petsc:

--- a/.ci_support/linux_aarch64_mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpiscalarreal.yaml
@@ -32,6 +32,8 @@ mpi:
 - openmpi
 mpich:
 - '4'
+mumps_mpi:
+- 5.6.2
 openmpi:
 - '4'
 petsc:

--- a/.ci_support/linux_ppc64le_mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichscalarcomplex.yaml
@@ -28,6 +28,8 @@ mpi:
 - mpich
 mpich:
 - '4'
+mumps_mpi:
+- 5.6.2
 openmpi:
 - '4'
 petsc:

--- a/.ci_support/linux_ppc64le_mpimpichscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichscalarreal.yaml
@@ -28,6 +28,8 @@ mpi:
 - mpich
 mpich:
 - '4'
+mumps_mpi:
+- 5.6.2
 openmpi:
 - '4'
 petsc:

--- a/.ci_support/linux_ppc64le_mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpiscalarcomplex.yaml
@@ -28,6 +28,8 @@ mpi:
 - openmpi
 mpich:
 - '4'
+mumps_mpi:
+- 5.6.2
 openmpi:
 - '4'
 petsc:

--- a/.ci_support/linux_ppc64le_mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpiscalarreal.yaml
@@ -28,6 +28,8 @@ mpi:
 - openmpi
 mpich:
 - '4'
+mumps_mpi:
+- 5.6.2
 openmpi:
 - '4'
 petsc:

--- a/.ci_support/migrations/mumps_mpi562.yaml
+++ b/.ci_support/migrations/mumps_mpi562.yaml
@@ -1,0 +1,9 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+migrator_ts: 1702402876.5413122
+mumps_seq:
+- 5.6.2
+mumps_mpi:
+- 5.6.2

--- a/.ci_support/osx_64_mpimpichscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichscalarcomplex.yaml
@@ -28,6 +28,8 @@ mpi:
 - mpich
 mpich:
 - '4'
+mumps_mpi:
+- 5.6.2
 openmpi:
 - '4'
 petsc:

--- a/.ci_support/osx_64_mpimpichscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichscalarreal.yaml
@@ -28,6 +28,8 @@ mpi:
 - mpich
 mpich:
 - '4'
+mumps_mpi:
+- 5.6.2
 openmpi:
 - '4'
 petsc:

--- a/.ci_support/osx_64_mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpiscalarcomplex.yaml
@@ -28,6 +28,8 @@ mpi:
 - openmpi
 mpich:
 - '4'
+mumps_mpi:
+- 5.6.2
 openmpi:
 - '4'
 petsc:

--- a/.ci_support/osx_64_mpiopenmpiscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpiscalarreal.yaml
@@ -28,6 +28,8 @@ mpi:
 - openmpi
 mpich:
 - '4'
+mumps_mpi:
+- 5.6.2
 openmpi:
 - '4'
 petsc:

--- a/.ci_support/osx_arm64_mpimpichscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichscalarcomplex.yaml
@@ -28,6 +28,8 @@ mpi:
 - mpich
 mpich:
 - '4'
+mumps_mpi:
+- 5.6.2
 openmpi:
 - '4'
 petsc:

--- a/.ci_support/osx_arm64_mpimpichscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichscalarreal.yaml
@@ -28,6 +28,8 @@ mpi:
 - mpich
 mpich:
 - '4'
+mumps_mpi:
+- 5.6.2
 openmpi:
 - '4'
 petsc:

--- a/.ci_support/osx_arm64_mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpiscalarcomplex.yaml
@@ -28,6 +28,8 @@ mpi:
 - openmpi
 mpich:
 - '4'
+mumps_mpi:
+- 5.6.2
 openmpi:
 - '4'
 petsc:

--- a/.ci_support/osx_arm64_mpiopenmpiscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpiscalarreal.yaml
@@ -28,6 +28,8 @@ mpi:
 - openmpi
 mpich:
 - '4'
+mumps_mpi:
+- 5.6.2
 openmpi:
 - '4'
 petsc:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,24 @@
-*.pyc
+# User content belongs under recipe/.
+# Feedstock configuration goes in `conda-forge.yml`
+# Everything else is managed by the conda-smithy rerender process.
+# Please do not modify
 
-build_artifacts
+# Ignore all files and folders in root
+*
+!/conda-forge.yml
+
+# Don't ignore any files/folders if the parent folder is 'un-ignored'
+# This also avoids warnings when adding an already-checked file with an ignored parent.
+!/**/
+# Don't ignore any files/folders recursively in the following folders
+!/recipe/**
+!/.ci_support/**
+
+# Since we ignore files/folders recursively, any folders inside
+# build_artifacts gets ignored which trips some build systems.
+# To avoid that we 'un-ignore' all files/folders recursively
+# and only ignore the root build_artifacts folder.
+!/build_artifacts/**
+/build_artifacts
+
+*.pyc

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -57,12 +57,6 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
   cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
 fi
 
-if [[ "${sha:-}" == "" ]]; then
-  pushd ${FEEDSTOCK_ROOT}
-  sha=$(git rev-parse HEAD)
-  popd
-fi
-
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -21,6 +21,12 @@ if [ -z ${FEEDSTOCK_NAME} ]; then
     export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
 fi
 
+if [[ "${sha:-}" == "" ]]; then
+  pushd "${FEEDSTOCK_ROOT}"
+  sha=$(git rev-parse HEAD)
+  popd
+fi
+
 docker info
 
 # In order for the conda-build process in the container to write to the mounted

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "3.20.1" %}
 {% set sha256 = "5a36b664895881d3858d0644f56bf7bb922bdab70d732fa11cbf6442fec11806" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 {% set version_xy = version.rsplit(".", 1)[0] %}
 {% set mpi = mpi or 'mpich' %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,13 +39,13 @@ requirements:
     - libcblas
     - liblapack
     - {{ mpi }}
-    - mumps_mpi
+    - mumps-mpi
     - petsc {{ version_xy }}.* {{ scalar }}_*
     - scalapack
     - suitesparse
   run:
     - {{ mpi }}
-    - mumps_mpi
+    - mumps-mpi
     - petsc
     - scalapack
     - suitesparse

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,11 +39,15 @@ requirements:
     - libcblas
     - liblapack
     - {{ mpi }}
+    - mumps_mpi
     - petsc {{ version_xy }}.* {{ scalar }}_*
+    - scalapack
     - suitesparse
   run:
     - {{ mpi }}
+    - mumps_mpi
     - petsc
+    - scalapack
     - suitesparse
 
 test:


### PR DESCRIPTION
slepc links mumps and scalapack directly, so should express those dependencies. That way it will get rebuilt for migrations and have correct pins, etc.

Right now, slepc isn't loading because it is missing this dependency after the latest petsc rebuild due to this missing dependency.

